### PR TITLE
chore(deps): replace `import_map.json` with `deps.ts`

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,5 +1,4 @@
-import { parse } from "flags/mod.ts";
-
+import { flags } from "./deps.ts";
 import { default as logger } from "./log/mod.ts";
 import { type Command } from "./console/mod.ts";
 
@@ -37,7 +36,7 @@ if (import.meta.main) {
   ]);
 
   const command = Deno.args[0] ?? "";
-  const args = parse(Deno.args.slice(1));
+  const args = flags.parse(Deno.args.slice(1));
 
   if (commands.has(command)) {
     try {

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,6 @@
       ]
     }
   },
-  "importMap": "import_map.json",
   "lint": {
     "files": {
       "exclude": [

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,3 @@
+export * as colors from "https://deno.land/std@0.133.0/fmt/colors.ts";
+export * as asserts from "https://deno.land/std@0.133.0/testing/asserts.ts";
+export * as flags from "https://deno.land/std@0.133.0/flags/mod.ts";

--- a/import_map.json
+++ b/import_map.json
@@ -1,7 +1,0 @@
-{
-  "imports": {
-    "testing/": "https://deno.land/std@0.130.0/testing/",
-    "fmt/": "https://deno.land/std@0.130.0/fmt/",
-    "flags/": "https://deno.land/std@0.130.0/flags/"
-  }
-}

--- a/lock.json
+++ b/lock.json
@@ -1,5 +1,7 @@
 {
-  "https://deno.land/std@0.130.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
-  "https://deno.land/std@0.130.0/flags/mod.ts": "430cf2d1c26e00286373b2647ebdca637f7558505e88e9c108a4742cd184c916",
-  "https://deno.land/std@0.130.0/fmt/colors.ts": "30455035d6d728394781c10755351742dd731e3db6771b1843f9b9e490104d37"
+  "https://deno.land/std@0.133.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
+  "https://deno.land/std@0.133.0/flags/mod.ts": "9bd361fd5487f5e06cae4e0b5237a83c2908202f4a76944ba1312029f6c11b95",
+  "https://deno.land/std@0.133.0/fmt/colors.ts": "30455035d6d728394781c10755351742dd731e3db6771b1843f9b9e490104d37",
+  "https://deno.land/std@0.133.0/testing/_diff.ts": "9d849cd6877694152e01775b2d93f9d6b7aef7e24bfe3bfafc4d7a1ac8e9f392",
+  "https://deno.land/std@0.133.0/testing/asserts.ts": "b0ef969032882b1f7eb1c7571e313214baa1485f7b61cf35807b2434e254365c"
 }

--- a/log/handlers/console.test.ts
+++ b/log/handlers/console.test.ts
@@ -1,7 +1,9 @@
-import { assertEquals, assertStringIncludes } from "testing/asserts.ts";
+import { asserts } from "../../deps.ts";
 import { LogLevel } from "../level.ts";
 import { LogMessage } from "../message.ts";
 import { ConsoleHandler } from "./console.ts";
+
+const { assertEquals, assertStringIncludes } = asserts;
 
 class TestWriter implements Deno.WriterSync {
   public buffer: Uint8Array = new Uint8Array();

--- a/log/handlers/console.ts
+++ b/log/handlers/console.ts
@@ -1,4 +1,4 @@
-import * as colors from "fmt/colors.ts";
+import { colors } from "../../deps.ts";
 import { LogHandler } from "../handler.ts";
 import { LogMessage } from "../message.ts";
 import { getLevelValue, LogLevel } from "../level.ts";

--- a/log/level.test.ts
+++ b/log/level.test.ts
@@ -1,5 +1,7 @@
-import { assertEquals } from "testing/asserts.ts";
+import { asserts } from "../deps.ts";
 import { getLevelValue, LogLevel } from "./level.ts";
+
+const { assertEquals } = asserts;
 
 Deno.test("log level emergency", () => {
   assertEquals(LogLevel.EMERGENCY, "emergency");

--- a/log/logger.test.ts
+++ b/log/logger.test.ts
@@ -1,8 +1,10 @@
-import { assertEquals, assertStrictEquals } from "testing/asserts.ts";
+import { asserts } from "../deps.ts";
 import { LogHandler } from "./handler.ts";
 import { LogLevel } from "./level.ts";
 import { LogMessage } from "./message.ts";
 import { Logger } from "./logger.ts";
+
+const { assertEquals } = asserts;
 
 class TestHandler extends LogHandler {
   public messages: LogMessage[] = [];
@@ -60,7 +62,7 @@ Deno.test("accepts multiple handlers", () => {
 
   logger.debug(`a single message`);
 
-  assertStrictEquals(
+  assertEquals(
     (logger.handlers[0] as TestHandler).messages[0],
     (logger.handlers[1] as TestHandler).messages[0],
   );

--- a/log/message.test.ts
+++ b/log/message.test.ts
@@ -1,6 +1,8 @@
-import { assertEquals } from "testing/asserts.ts";
+import { asserts } from "../deps.ts";
 import { LogLevel } from "./level.ts";
 import { LogMessage } from "./message.ts";
+
+const { assertEquals } = asserts;
 
 Deno.test("log message", () => {
   const message = new LogMessage(LogLevel.DEBUG, "Hello World!");


### PR DESCRIPTION
To avoid consumers having to reference our own `import_map.json` every time, this PR moves back to using `deps.ts` to reference the dependencies.