### PR TITLE
fix(log): print log to stdout/stderr via console obj

### DIFF
--- a/error/deps.ts
+++ b/error/deps.ts
@@ -1,4 +1,4 @@
 export {
 	assertEquals,
 	assertThrows,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.155.0/testing/asserts.ts";

--- a/lock.json
+++ b/lock.json
@@ -1,11 +1,8 @@
 {
-  "https://deno.land/std@0.152.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
-  "https://deno.land/std@0.152.0/flags/mod.ts": "34bb4148ad1cbdf1e3d20e1541f36c8a5b47205e3a5ee4e62a71eab89215011b",
-  "https://deno.land/std@0.152.0/fmt/colors.ts": "6f9340b7fb8cc25a993a99e5efc56fe81bb5af284ff412129dd06df06f53c0b4",
-  "https://deno.land/std@0.152.0/testing/_diff.ts": "029a00560b0d534bc0046f1bce4bd36b3b41ada3f2a3178c85686eb2ff5f1413",
-  "https://deno.land/std@0.152.0/testing/_format.ts": "0d8dc79eab15b67cdc532826213bbe05bccfd276ca473a50a3fc7bbfb7260642",
-  "https://deno.land/std@0.152.0/testing/_test_suite.ts": "ad453767aeb8c300878a6b7920e20370f4ce92a7b6c8e8a5d1ac2b7c14a09acb",
-  "https://deno.land/std@0.152.0/testing/asserts.ts": "093735c88f52bbead7f60a1f7a97a2ce4df3c2d5fab00a46956f20b4a5793ccd",
-  "https://deno.land/std@0.152.0/testing/bdd.ts": "311d19d872088e254ead39eb7742630f7b17547ca4847dbd670821c02789a0f9",
-  "https://deno.land/std@0.152.0/testing/mock.ts": "c7cc7eae6eecbe692798bd7ce155f81a9c600865b0b2e8799068e8a85cc83b3d"
+  "https://deno.land/std@0.155.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
+  "https://deno.land/std@0.155.0/flags/mod.ts": "96c6bf6b1e3505c5f81db138c3312e5ceec8a639d8c26a14497d8fd3aa603f45",
+  "https://deno.land/std@0.155.0/fmt/colors.ts": "ff7dc9c9f33a72bd48bc24b21bbc1b4545d8494a431f17894dbc5fe92a938fc4",
+  "https://deno.land/std@0.155.0/testing/_diff.ts": "a23e7fc2b4d8daa3e158fa06856bedf5334ce2a2831e8bf9e509717f455adb2c",
+  "https://deno.land/std@0.155.0/testing/_format.ts": "cd11136e1797791045e639e9f0f4640d5b4166148796cad37e6ef75f7d7f3832",
+  "https://deno.land/std@0.155.0/testing/asserts.ts": "ac295f7fd22a7af107580e2475402a8c386cb1bf18bf837ae266ac0665786026"
 }

--- a/log/deps.ts
+++ b/log/deps.ts
@@ -1,3 +1,3 @@
-export * as asserts from "https://deno.land/std@0.152.0/testing/asserts.ts";
-export * as colors from "https://deno.land/std@0.152.0/fmt/colors.ts";
-export * as flags from "https://deno.land/std@0.152.0/flags/mod.ts";
+export * as asserts from "https://deno.land/std@0.155.0/testing/asserts.ts";
+export * as colors from "https://deno.land/std@0.155.0/fmt/colors.ts";
+export * as flags from "https://deno.land/std@0.155.0/flags/mod.ts";

--- a/log/handlers/console.ts
+++ b/log/handlers/console.ts
@@ -37,6 +37,10 @@ export class ConsoleHandler extends LogHandler {
 
 		if (getLevelValue(record.level) <= getLevelValue(LogLevel.ERROR)) {
 			console.error(formatted);
+		} else if (record.level === LogLevel.WARNING) {
+			console.warn(formatted);
+		} else if (record.level === LogLevel.DEBUG) {
+			console.debug(formatted);
 		} else {
 			console.log(formatted);
 		}

--- a/log/handlers/console.ts
+++ b/log/handlers/console.ts
@@ -9,25 +9,25 @@ export type ConsoleHandlerOptions = {
 	/** Show colors on the console output. Defaults to `true` */
 	color?: boolean;
 
-	/** Add datetime to the log message. Defaults to `false` */
-	datetime?: boolean;
+	/** Add timestamp to the log message. Defaults to `false` */
+	timestamp?: boolean;
 
 	/** Format log message as JSON. Defaults to `false` */
 	json?: boolean;
 };
 
 export class ConsoleHandler extends LogHandler {
-	#color: ConsoleHandlerOptions["color"];
-	#datetime: ConsoleHandlerOptions["datetime"];
-	#json: ConsoleHandlerOptions["json"];
-	#name: ConsoleHandlerOptions["name"];
+	#color: boolean;
+	#timestamp: boolean;
+	#json: boolean;
+	#name: boolean;
 
 	constructor(options?: ConsoleHandlerOptions) {
 		super();
 		this.#color = options?.color ?? true;
 		this.#json = options?.json ?? false;
 		this.#name = options?.name ?? false;
-		this.#datetime = options?.datetime ?? false;
+		this.#timestamp = options?.timestamp ?? false;
 	}
 
 	override handle(
@@ -48,7 +48,7 @@ export class ConsoleHandler extends LogHandler {
 		if (this.#json) {
 			return JSON.stringify({
 				...(this.#name && { name: loggerName }),
-				...(this.#datetime && { datetime: record.datetime }),
+				...(this.#timestamp && { timestamp: record.timestamp }),
 				level: record.level,
 				message: record.message,
 			});
@@ -64,11 +64,11 @@ export class ConsoleHandler extends LogHandler {
 			}
 		}
 
-		if (this.#datetime) {
+		if (this.#timestamp) {
 			if (this.#color) {
-				output.push(colors.gray(record.datetime));
+				output.push(colors.gray(record.timestamp));
 			} else {
-				output.push(record.datetime);
+				output.push(record.timestamp);
 			}
 		}
 

--- a/log/handlers/console.ts
+++ b/log/handlers/console.ts
@@ -14,16 +14,6 @@ export type ConsoleHandlerOptions = {
 
 	/** Format log message as JSON. Defaults to `false` */
 	json?: boolean;
-
-	/**
-	 * Target for the log messages.
-	 *
-	 * | Default       | Level                                         |
-	 * |:--------------|:----------------------------------------------|
-	 * | `Deno.stdout` | `debug`, `info`, `notice`, and `warning`      |
-	 * | `Deno.stderr` | `error`, `critical`, `alert`, and `emergency` |
-	 */
-	target?: Deno.Writer;
 };
 
 export class ConsoleHandler extends LogHandler {
@@ -31,32 +21,25 @@ export class ConsoleHandler extends LogHandler {
 	#datetime: ConsoleHandlerOptions["datetime"];
 	#json: ConsoleHandlerOptions["json"];
 	#name: ConsoleHandlerOptions["name"];
-	#target: Required<ConsoleHandlerOptions["target"]>;
 
 	constructor(options?: ConsoleHandlerOptions) {
 		super();
 		this.#color = options?.color ?? true;
 		this.#json = options?.json ?? false;
 		this.#name = options?.name ?? false;
-		this.#target = options?.target ?? Deno.stdout;
 		this.#datetime = options?.datetime ?? false;
 	}
 
-	override async handle(
+	override handle(
 		{ loggerName, record }: LogHandlerOptions,
-	): Promise<string> {
-		if (
-			this.#target === Deno.stdout &&
-			getLevelValue(record.level) <= getLevelValue(LogLevel.ERROR)
-		) {
-			this.#target = Deno.stderr;
-		}
-
+	): string {
 		const formatted = this.format({ loggerName, record });
 
-		await this.#target?.write(
-			new TextEncoder().encode(`${formatted}\n`),
-		);
+		if (getLevelValue(record.level) <= getLevelValue(LogLevel.ERROR)) {
+			console.error(formatted);
+		} else {
+			console.log(formatted);
+		}
 
 		return formatted;
 	}

--- a/log/handlers/console_test.fixture.color.ts
+++ b/log/handlers/console_test.fixture.color.ts
@@ -1,0 +1,10 @@
+import { Logger } from "../logger.ts";
+import { ConsoleHandler } from "./console.ts";
+
+const logger = new Logger("color", {
+	handlers: [
+		new ConsoleHandler(),
+	],
+});
+
+logger.debug("hello");

--- a/log/handlers/console_test.fixture.json.ts
+++ b/log/handlers/console_test.fixture.json.ts
@@ -1,0 +1,12 @@
+import { Logger } from "../logger.ts";
+import { ConsoleHandler } from "./console.ts";
+
+const logger = new Logger("json", {
+	handlers: [
+		new ConsoleHandler({
+			json: true,
+		}),
+	],
+});
+
+logger.debug("hello");

--- a/log/handlers/console_test.fixture.level.ts
+++ b/log/handlers/console_test.fixture.level.ts
@@ -1,0 +1,13 @@
+import { LogLevel } from "../level.ts";
+import { Logger } from "../logger.ts";
+import { ConsoleHandler } from "./console.ts";
+
+const logger = new Logger("level", {
+	handlers: [
+		new ConsoleHandler(),
+	],
+});
+
+Object.values(LogLevel).forEach((level) => {
+	logger[level]?.(`a message with '${level}' level`);
+});

--- a/log/handlers/console_test.fixture.name.ts
+++ b/log/handlers/console_test.fixture.name.ts
@@ -1,0 +1,12 @@
+import { Logger } from "../logger.ts";
+import { ConsoleHandler } from "./console.ts";
+
+const logger = new Logger("name", {
+	handlers: [
+		new ConsoleHandler({
+			name: true,
+		}),
+	],
+});
+
+logger.debug("this is a debug message");

--- a/log/handlers/console_test.fixture.timestamp.ts
+++ b/log/handlers/console_test.fixture.timestamp.ts
@@ -1,0 +1,12 @@
+import { Logger } from "../logger.ts";
+import { ConsoleHandler } from "./console.ts";
+
+const logger = new Logger("timestamp", {
+	handlers: [
+		new ConsoleHandler({
+			timestamp: true,
+		}),
+	],
+});
+
+logger.debug("this is a debug message");

--- a/log/handlers/console_test.ts
+++ b/log/handlers/console_test.ts
@@ -7,14 +7,14 @@ const decoder = new TextDecoder();
 	const [stdout, stderr] = await runFixture("level");
 
 	// stdout
-	for (const level of ["debug", "info", "notice", "warning"]) {
+	for (const level of ["debug", "info", "notice"]) {
 		Deno.test(`ConsoleHandler writes to stdout for \`${level}\` level`, () => {
 			assertStringIncludes(stdout, level);
 		});
 	}
 
 	// stderr
-	for (const level of ["error", "critical", "emergency"]) {
+	for (const level of ["warning", "error", "critical", "emergency"]) {
 		Deno.test(`ConsoleHandler writes to stderr for \`${level}\` level`, () => {
 			assertStringIncludes(stderr, level);
 		});

--- a/log/handlers/console_test.ts
+++ b/log/handlers/console_test.ts
@@ -1,106 +1,73 @@
 import { asserts } from "../deps.ts";
-import { LogLevel } from "../level.ts";
-import { Logger } from "../logger.ts";
-import { LogRecord } from "../record.ts";
-import { ConsoleHandler } from "./console.ts";
 
 const { assertEquals, assertStringIncludes } = asserts;
+const decoder = new TextDecoder();
 
-class TestWriter implements Deno.Writer {
-	public buffer: Uint8Array = new Uint8Array();
+{
+	const [stdout, stderr] = await runFixture("level");
 
-	async write(data: Uint8Array): Promise<number> {
-		this.buffer = data;
-		return await data.buffer.byteLength;
+	// stdout
+	for (const level of ["debug", "info", "notice", "warning"]) {
+		Deno.test(`ConsoleHandler writes to stdout for \`${level}\` level`, () => {
+			assertStringIncludes(stdout, level);
+		});
+	}
+
+	// stderr
+	for (const level of ["error", "critical", "emergency"]) {
+		Deno.test(`ConsoleHandler writes to stderr for \`${level}\` level`, () => {
+			assertStringIncludes(stderr, level);
+		});
 	}
 }
 
-Deno.test("ConsoleHandler prints the logger name", () => {
-	const writer = new TestWriter();
-	const logger = new Logger("test", {
-		handlers: [
-			new ConsoleHandler({
-				name: true,
-				target: writer,
-			}),
-		],
-	});
+Deno.test("ConsoleHandler prints the logger name", async () => {
+	const [stdout] = await runFixture("name");
+	assertStringIncludes(stdout.split("\n").at(0) ?? "", "[name]");
+});
 
-	logger.debug("this is a debug message");
+Deno.test("ConsoleHandler prints the timestamp for a log record", async () => {
+	const [stdout] = await runFixture("timestamp");
 
 	assertStringIncludes(
-		new TextDecoder().decode(writer.buffer),
-		"[test]",
+		stdout.split("\n").at(0) ?? "",
+		new Date().toISOString().slice(0, -4),
 	);
 });
 
-Deno.test("ConsoleHandler prints the datetime for a log record", () => {
-	const record = new LogRecord({ level: LogLevel.DEBUG, message: "hello" });
-	const writer = new TestWriter();
-	const handler = new ConsoleHandler({
-		color: false,
-		target: writer,
-		datetime: true,
-	});
-
-	handler.handle({ record });
-
-	assertEquals(
-		new TextDecoder().decode(writer.buffer),
-		`${record.datetime} debug hello\n`,
-	);
+Deno.test("ConsoleHandler formats a record to JSON", async () => {
+	const [stdout] = await runFixture("json");
+	assertEquals(stdout, `{"level":"debug","message":"hello"}\n`);
 });
 
-Deno.test("ConsoleHandler formats a record to JSON", () => {
-	const record = new LogRecord({ level: LogLevel.DEBUG, message: "hello" });
-	const writer = new TestWriter();
-	const handler = new ConsoleHandler({
-		json: true,
-		target: writer,
-	});
-
-	handler.handle({ record });
-
-	assertEquals(
-		new TextDecoder().decode(writer.buffer),
-		`{"level":"debug","message":"hello"}\n`,
-	);
-});
-
-Deno.test("ConsoleHandler colorizes a log record level", () => {
-	const record = new LogRecord({ level: LogLevel.DEBUG, message: "hello" });
-	const writer = new TestWriter();
-	const handler = new ConsoleHandler({
-		color: true,
-		target: writer,
-	});
-
-	handler.handle({ record });
+Deno.test("ConsoleHandler colorizes a log record level", async () => {
+	const [stdout] = await runFixture("color");
 
 	// [90mdebug[39m
 	// ^^^^---------
-	assertStringIncludes(
-		new TextDecoder().decode(writer.buffer).slice(0, 5),
-		"[90m",
-	);
+	assertStringIncludes(stdout, "[90m");
 
 	// [90mdebug[39m
 	// ---------^^^^
-	assertStringIncludes(
-		new TextDecoder().decode(writer.buffer).slice(11, 15),
-		"[39m",
-	);
+	assertStringIncludes(stdout.slice(11, 15), "[39m");
 });
 
-// TODO(gabrielizaias): figure out how to mock stdout/stderr
-Deno.test(
-	"ConsoleHandler defaults to stdout for `debug`, `info`, `notice`, and `warning`",
-	{ ignore: true },
-	() => {},
-);
+/** run a test fixture on a sub-process to and caputure the output for assertions */
+async function runFixture(fixture: string): Promise<[string, string]> {
+	const process = Deno.run({
+		cmd: [
+			"deno",
+			"run",
+			`./log/handlers/console_test.fixture.${fixture}.ts`,
+		],
+		stdout: "piped",
+		stderr: "piped",
+	});
 
-Deno.test(
-	"ConsoleHandler defaults to stderr for `error`, `critical`, `alert`, and `emergency`",
-	{ ignore: true },
-	() => {},
-);
+	const stdout = decoder.decode(await process.output());
+	const stderr = decoder.decode(await process.stderrOutput());
+
+	process.close();
+
+	return [stdout, stderr];
+}

--- a/log/logger.ts
+++ b/log/logger.ts
@@ -20,7 +20,7 @@ export class Logger {
 
 	/** Logs a message with emergency level */
 	emergency(
-		message: LogRecord["message"],
+		message?: LogRecord["message"],
 		...args: LogRecordOptions["args"][]
 	): void {
 		this.#log(LogLevel.EMERGENCY, message, ...args);
@@ -28,7 +28,7 @@ export class Logger {
 
 	/** Logs a message with alert level */
 	alert(
-		message: LogRecord["message"],
+		message?: LogRecord["message"],
 		...args: LogRecordOptions["args"][]
 	): void {
 		this.#log(LogLevel.ALERT, message, ...args);
@@ -36,7 +36,7 @@ export class Logger {
 
 	/** Logs a message with critical level */
 	critical(
-		message: LogRecord["message"],
+		message?: LogRecord["message"],
 		...args: LogRecordOptions["args"][]
 	): void {
 		this.#log(LogLevel.CRITICAL, message, ...args);
@@ -44,7 +44,7 @@ export class Logger {
 
 	/** Logs a message with error level */
 	error(
-		message: LogRecord["message"],
+		message?: LogRecord["message"],
 		...args: LogRecordOptions["args"][]
 	): void {
 		this.#log(LogLevel.ERROR, message, ...args);
@@ -52,7 +52,7 @@ export class Logger {
 
 	/** Logs a message with warning level */
 	warning(
-		message: LogRecord["message"],
+		message?: LogRecord["message"],
 		...args: LogRecordOptions["args"][]
 	): void {
 		this.#log(LogLevel.WARNING, message, ...args);
@@ -60,7 +60,7 @@ export class Logger {
 
 	/** Logs a message with notice level */
 	notice(
-		message: LogRecord["message"],
+		message?: LogRecord["message"],
 		...args: LogRecordOptions["args"][]
 	): void {
 		this.#log(LogLevel.NOTICE, message, ...args);
@@ -68,7 +68,7 @@ export class Logger {
 
 	/** Logs a message with info level */
 	info(
-		message: LogRecord["message"],
+		message?: LogRecord["message"],
 		...args: LogRecordOptions["args"][]
 	): void {
 		this.#log(LogLevel.INFO, message, ...args);
@@ -76,7 +76,7 @@ export class Logger {
 
 	/** Logs a message with debug level */
 	debug(
-		message: LogRecord["message"],
+		message?: LogRecord["message"],
 		...args: LogRecordOptions["args"][]
 	): void {
 		this.#log(LogLevel.DEBUG, message, ...args);
@@ -84,7 +84,7 @@ export class Logger {
 
 	#log(
 		level: LogLevel,
-		message: LogRecord["message"],
+		message?: LogRecord["message"],
 		...args: LogRecordOptions["args"][]
 	): void {
 		const record = new LogRecord({ level, message, args });

--- a/log/readme.md
+++ b/log/readme.md
@@ -48,8 +48,8 @@ A message will be passed to each handler in turn.
 
 The `ConsoleHandler` writes log messages to the console.
 
-If the log level is `debug`, `info`, `notice` or `warning`, the message is
-written to `Deno.stdout`. Conversely, if the log level is `error`, `critical`,
+If the log level is `debug`, `info` or `notice`, the message is written to
+`Deno.stdout`. Conversely, if the log level is `warning`, `error`, `critical`,
 `alert` or `emergency`, the message is written to `Deno.stderr`.
 
 You can optionally configure the `ConsoleHandler` instance to include a

--- a/log/record.ts
+++ b/log/record.ts
@@ -2,7 +2,7 @@ import { type LogLevel } from "./level.ts";
 
 export type LogRecordOptions = {
 	level: LogRecord["level"];
-	message: LogRecord["message"];
+	message?: LogRecord["message"];
 	args?: unknown[];
 };
 
@@ -10,19 +10,19 @@ export type LogRecordOptions = {
 export class LogRecord<T = any> {
 	readonly level: LogLevel;
 	readonly message: T;
-	readonly #args: LogRecordOptions["args"];
-	#datetime: Date;
+	readonly #args: unknown[];
+	#timestamp: string;
 
 	constructor({ level, message, args }: LogRecordOptions) {
 		this.level = level;
 		this.message = message;
 		this.#args = [...(args ?? [])];
-		this.#datetime = new Date();
+		this.#timestamp = new Date().toISOString();
 	}
 
-	/** The date and time the log record was created, in ISO format */
-	get datetime(): string {
-		return new Date(this.#datetime).toISOString();
+	/** The timestamp log record was created, in ISO format */
+	get timestamp(): string {
+		return this.#timestamp;
 	}
 
 	get args(): LogRecordOptions["args"] {

--- a/log/record_test.ts
+++ b/log/record_test.ts
@@ -90,5 +90,5 @@ Deno.test("LogRecord has a datetime in ISO format", () => {
 		level: LogLevel.EMERGENCY,
 		message: "Hello World!",
 	});
-	assertEquals(record.datetime, new Date(record.datetime).toISOString());
+	assertEquals(record.timestamp, new Date(record.timestamp).toISOString());
 });

--- a/website/deps.ts
+++ b/website/deps.ts
@@ -1,2 +1,2 @@
-export { serve } from "https://deno.land/std@0.152.0/http/server.ts";
-export { serveFile } from "https://deno.land/std@0.152.0/http/file_server.ts";
+export { serve } from "https://deno.land/std@0.155.0/http/server.ts";
+export { serveFile } from "https://deno.land/std@0.155.0/http/file_server.ts";


### PR DESCRIPTION
fixes #15

- prints log records using `console` under the hood
  - `LogLevel.DEBUG` uses `console.debug()`
  - `LogLevel.WARNING` uses `console.warn()`
  - `LogLevel.ERROR` and above uses `console.error()`
- add tests for `ConsoleHandler` using spawned sub-process to isolate fixtures