### PR TITLE
fix(website): import map deps for deno deploy

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
 	"tasks": {
-		"cache": "deno cache -r cli.ts console/mod.ts error/mod.ts http/mod.ts",
-		"check": "deno check -r cli.ts console/mod.ts error/mod.ts http/mod.ts",
+		"cache": "deno cache -r cli.ts console/mod.ts error/mod.ts http/mod.ts website/main.ts",
+		"check": "deno check -r cli.ts console/mod.ts error/mod.ts http/mod.ts website/main.ts",
 		"test": "deno test -A --no-check --coverage=./cov"
 	},
 	"workspace": [

--- a/deno.lock
+++ b/deno.lock
@@ -160,6 +160,14 @@
       "jsr:@std/http@^1.0.4",
       "jsr:@std/log@^0.224.6",
       "jsr:@std/path@^1.0.3"
-    ]
+    ],
+    "members": {
+      "website": {
+        "dependencies": [
+          "jsr:@std/http@^1.0.4",
+          "jsr:@std/log@^0.224.6"
+        ]
+      }
+    }
   }
 }

--- a/website/deno.json
+++ b/website/deno.json
@@ -2,5 +2,9 @@
 	"$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
 	"tasks": {
 		"dev": "deno run -A --watch ./main.ts"
+	},
+	"imports": {
+		"@std/http": "jsr:@std/http@^1.0.4",
+		"@std/log": "jsr:@std/log@^0.224.6"
 	}
 }


### PR DESCRIPTION
Deno Deploy does not pick up the import map from the root `deno.json`, even if the `website` folder is configured as a workspace member.

This PR adds the import map entries necessary for the website to be correctly deployed.